### PR TITLE
Add src-based site structure

### DIFF
--- a/givoro-app/README.md
+++ b/givoro-app/README.md
@@ -1,10 +1,6 @@
 # GIVORO Marketing Site
 
-This is a starter Next.js project for GIVORO's marketing website. It includes:
-
-- Tailwind CSS for styling
-- Basic pages and navigation
-- Placeholder components for case studies and blog
+This project uses Next.js and Tailwind CSS. Core pages and UI components live in the `src` directory.
 
 Install dependencies with `npm install` and start the dev server with `npm run dev`.
 

--- a/givoro-app/src/components/about/WhatWeDo.js
+++ b/givoro-app/src/components/about/WhatWeDo.js
@@ -1,0 +1,8 @@
+export default function WhatWeDo() {
+  return (
+    <section className="mb-8">
+      <h2 className="text-2xl font-semibold mb-2">What We Do</h2>
+      <p>We connect brands to audiences through useful, trackable products distributed at scale.</p>
+    </section>
+  );
+}

--- a/givoro-app/src/components/about/WhoWeAre.js
+++ b/givoro-app/src/components/about/WhoWeAre.js
@@ -1,0 +1,8 @@
+export default function WhoWeAre() {
+  return (
+    <section className="mb-8">
+      <h2 className="text-2xl font-semibold mb-2">Who We Are</h2>
+      <p>We are a new-era ad-tech company bringing real-world value to brands and consumers.</p>
+    </section>
+  );
+}

--- a/givoro-app/src/components/about/WhyWeMatter.js
+++ b/givoro-app/src/components/about/WhyWeMatter.js
@@ -1,0 +1,8 @@
+export default function WhyWeMatter() {
+  return (
+    <section className="mb-8">
+      <h2 className="text-2xl font-semibold mb-2">Why We Matter</h2>
+      <p>Our approach delivers measurable impact and high visibility while giving real value to people on the ground.</p>
+    </section>
+  );
+}

--- a/givoro-app/src/components/forms/ContactForm.js
+++ b/givoro-app/src/components/forms/ContactForm.js
@@ -1,0 +1,10 @@
+export default function ContactForm() {
+  return (
+    <form className="space-y-4">
+      <input type="text" placeholder="Name" className="w-full border p-2" required />
+      <input type="email" placeholder="Email" className="w-full border p-2" required />
+      <textarea placeholder="Message" className="w-full border p-2" rows="4" />
+      <button type="submit" className="px-4 py-2 bg-accent text-black font-semibold rounded">Send</button>
+    </form>
+  );
+}

--- a/givoro-app/src/components/hero/Hero.js
+++ b/givoro-app/src/components/hero/Hero.js
@@ -1,0 +1,14 @@
+import Link from 'next/link';
+
+export default function Hero() {
+  return (
+    <section className="min-h-screen flex flex-col items-center justify-center text-center p-8 bg-[url('/images/hero.jpg')] bg-cover bg-center">
+      <h1 className="text-4xl md:text-6xl font-bold text-white drop-shadow-lg">Reimagining Reach. One Hand-off at a Time.</h1>
+      <p className="mt-4 text-lg text-white max-w-xl">We turn branded utility into trackable engagement. Give value. Get visibility.</p>
+      <div className="mt-8 flex space-x-4">
+        <Link href="/solutions" className="px-6 py-3 bg-accent text-black font-semibold rounded">Our Solutions</Link>
+        <Link href="/platform" className="px-6 py-3 border border-white text-white font-semibold rounded">How It Works</Link>
+      </div>
+    </section>
+  );
+}

--- a/givoro-app/src/components/impact/ImpactPillars.js
+++ b/givoro-app/src/components/impact/ImpactPillars.js
@@ -1,0 +1,15 @@
+const pillars = [
+  'Audience Development',
+  'Product Launches',
+  'ROI & Attribution',
+];
+
+export default function ImpactPillars() {
+  return (
+    <div className="grid md:grid-cols-3 gap-4">
+      {pillars.map((p) => (
+        <div key={p} className="border p-4 text-center rounded">{p}</div>
+      ))}
+    </div>
+  );
+}

--- a/givoro-app/src/components/layout/Footer.js
+++ b/givoro-app/src/components/layout/Footer.js
@@ -1,0 +1,7 @@
+export default function Footer() {
+  return (
+    <footer className="p-4 text-center border-t">
+      © {new Date().getFullYear()} GIVORO
+    </footer>
+  );
+}

--- a/givoro-app/src/components/layout/Header.js
+++ b/givoro-app/src/components/layout/Header.js
@@ -1,0 +1,19 @@
+import Link from 'next/link';
+
+export default function Header() {
+  return (
+    <header className="p-4 flex justify-between items-center border-b">
+      <Link href="/" className="font-bold text-xl">GIVORO</Link>
+      <nav className="space-x-4">
+        <Link href="/">Home</Link>
+        <Link href="/about">About</Link>
+        <Link href="/solutions">Solutions</Link>
+        <Link href="/platform">Platform</Link>
+        <Link href="/impact">Impact</Link>
+        <Link href="/contact">Contact</Link>
+        <Link href="/auth/login">Login</Link>
+        <Link href="/auth/signup">Sign Up</Link>
+      </nav>
+    </header>
+  );
+}

--- a/givoro-app/src/components/layout/Layout.js
+++ b/givoro-app/src/components/layout/Layout.js
@@ -1,0 +1,12 @@
+import Header from './Header';
+import Footer from './Footer';
+
+export default function Layout({ children }) {
+  return (
+    <div className="flex flex-col min-h-screen">
+      <Header />
+      <main className="flex-grow">{children}</main>
+      <Footer />
+    </div>
+  );
+}

--- a/givoro-app/src/components/platform/FeatureList.js
+++ b/givoro-app/src/components/platform/FeatureList.js
@@ -1,0 +1,15 @@
+const features = [
+  'Dashboard for campaign stats',
+  'QR tracking and engagement',
+  'Automated distribution reporting',
+];
+
+export default function FeatureList() {
+  return (
+    <ul className="list-disc list-inside space-y-2">
+      {features.map((f) => (
+        <li key={f}>{f}</li>
+      ))}
+    </ul>
+  );
+}

--- a/givoro-app/src/components/platform/HowItWorks.js
+++ b/givoro-app/src/components/platform/HowItWorks.js
@@ -1,0 +1,17 @@
+const steps = [
+  'Choose your product',
+  'Production & Branding',
+  'Distribution with QR tracking',
+  'Monitor data in dashboard',
+  'Optimize and repeat',
+];
+
+export default function HowItWorks() {
+  return (
+    <ol className="list-decimal list-inside space-y-2">
+      {steps.map((s) => (
+        <li key={s}>{s}</li>
+      ))}
+    </ol>
+  );
+}

--- a/givoro-app/src/components/platform/PlatformIntro.js
+++ b/givoro-app/src/components/platform/PlatformIntro.js
@@ -1,0 +1,8 @@
+export default function PlatformIntro() {
+  return (
+    <section className="mb-8">
+      <h2 className="text-2xl font-semibold mb-2">Our Platform</h2>
+      <p>Seamlessly manage your on-ground campaigns with end-to-end visibility.</p>
+    </section>
+  );
+}

--- a/givoro-app/src/components/solutions/SolutionCard.js
+++ b/givoro-app/src/components/solutions/SolutionCard.js
@@ -1,0 +1,8 @@
+export default function SolutionCard({ title, children }) {
+  return (
+    <div className="border p-4 rounded shadow-sm">
+      <h3 className="font-semibold mb-2">{title}</h3>
+      <p>{children}</p>
+    </div>
+  );
+}

--- a/givoro-app/src/components/solutions/SolutionsGrid.js
+++ b/givoro-app/src/components/solutions/SolutionsGrid.js
@@ -1,0 +1,18 @@
+import SolutionCard from './SolutionCard';
+
+const solutions = [
+  { title: 'Campaign Planning', description: 'Strategic on-ground execution.' },
+  { title: 'Product Design', description: 'Custom-branded utility items.' },
+  { title: 'Tracking & Automation', description: 'QR codes and distribution tech.' },
+  { title: 'Analytics', description: 'Monitor impact in real time.' },
+];
+
+export default function SolutionsGrid() {
+  return (
+    <div className="grid md:grid-cols-2 gap-4">
+      {solutions.map((s) => (
+        <SolutionCard key={s.title} title={s.title}>{s.description}</SolutionCard>
+      ))}
+    </div>
+  );
+}

--- a/givoro-app/src/pages/_app.js
+++ b/givoro-app/src/pages/_app.js
@@ -1,0 +1,5 @@
+import '../styles/globals.css';
+
+export default function MyApp({ Component, pageProps }) {
+  return <Component {...pageProps} />;
+}

--- a/givoro-app/src/pages/_document.js
+++ b/givoro-app/src/pages/_document.js
@@ -1,0 +1,13 @@
+import { Html, Head, Main, NextScript } from 'next/document';
+
+export default function Document() {
+  return (
+    <Html lang="en">
+      <Head />
+      <body>
+        <Main />
+        <NextScript />
+      </body>
+    </Html>
+  );
+}

--- a/givoro-app/src/pages/about.js
+++ b/givoro-app/src/pages/about.js
@@ -1,0 +1,16 @@
+import Layout from '../components/layout/Layout';
+import WhoWeAre from '../components/about/WhoWeAre';
+import WhatWeDo from '../components/about/WhatWeDo';
+import WhyWeMatter from '../components/about/WhyWeMatter';
+
+export default function About() {
+  return (
+    <Layout>
+      <div className="p-8 max-w-3xl mx-auto">
+        <WhoWeAre />
+        <WhatWeDo />
+        <WhyWeMatter />
+      </div>
+    </Layout>
+  );
+}

--- a/givoro-app/src/pages/auth/login.js
+++ b/givoro-app/src/pages/auth/login.js
@@ -1,0 +1,16 @@
+import Layout from '../../components/layout/Layout';
+
+export default function Login() {
+  return (
+    <Layout>
+      <main className="p-8 max-w-md mx-auto">
+        <h1 className="text-3xl font-bold mb-4">Login</h1>
+        <form className="space-y-4">
+          <input type="email" placeholder="Email" className="w-full border p-2" required />
+          <input type="password" placeholder="Password" className="w-full border p-2" required />
+          <button type="submit" className="px-4 py-2 bg-black text-white rounded">Login</button>
+        </form>
+      </main>
+    </Layout>
+  );
+}

--- a/givoro-app/src/pages/auth/signup.js
+++ b/givoro-app/src/pages/auth/signup.js
@@ -1,0 +1,16 @@
+import Layout from '../../components/layout/Layout';
+
+export default function Signup() {
+  return (
+    <Layout>
+      <main className="p-8 max-w-md mx-auto">
+        <h1 className="text-3xl font-bold mb-4">Sign Up</h1>
+        <form className="space-y-4">
+          <input type="email" placeholder="Email" className="w-full border p-2" required />
+          <input type="password" placeholder="Password" className="w-full border p-2" required />
+          <button type="submit" className="px-4 py-2 bg-black text-white rounded">Create Account</button>
+        </form>
+      </main>
+    </Layout>
+  );
+}

--- a/givoro-app/src/pages/contact.js
+++ b/givoro-app/src/pages/contact.js
@@ -1,0 +1,13 @@
+import Layout from '../components/layout/Layout';
+import ContactForm from '../components/forms/ContactForm';
+
+export default function Contact() {
+  return (
+    <Layout>
+      <main className="p-8 max-w-md mx-auto">
+        <h1 className="text-3xl font-bold mb-4">Contact Us</h1>
+        <ContactForm />
+      </main>
+    </Layout>
+  );
+}

--- a/givoro-app/src/pages/impact.js
+++ b/givoro-app/src/pages/impact.js
@@ -1,0 +1,13 @@
+import Layout from '../components/layout/Layout';
+import ImpactPillars from '../components/impact/ImpactPillars';
+
+export default function Impact() {
+  return (
+    <Layout>
+      <main className="p-8 max-w-3xl mx-auto">
+        <h1 className="text-3xl font-bold mb-4">Impact</h1>
+        <ImpactPillars />
+      </main>
+    </Layout>
+  );
+}

--- a/givoro-app/src/pages/index.js
+++ b/givoro-app/src/pages/index.js
@@ -1,0 +1,10 @@
+import Layout from '../components/layout/Layout';
+import Hero from '../components/hero/Hero';
+
+export default function Home() {
+  return (
+    <Layout>
+      <Hero />
+    </Layout>
+  );
+}

--- a/givoro-app/src/pages/platform.js
+++ b/givoro-app/src/pages/platform.js
@@ -1,0 +1,19 @@
+import Layout from '../components/layout/Layout';
+import PlatformIntro from '../components/platform/PlatformIntro';
+import FeatureList from '../components/platform/FeatureList';
+import HowItWorks from '../components/platform/HowItWorks';
+
+export default function Platform() {
+  return (
+    <Layout>
+      <main className="p-8 max-w-3xl mx-auto">
+        <PlatformIntro />
+        <FeatureList />
+        <div className="mt-4">
+          <h2 className="text-2xl font-semibold mb-2">How It Works</h2>
+          <HowItWorks />
+        </div>
+      </main>
+    </Layout>
+  );
+}

--- a/givoro-app/src/pages/solutions/index.js
+++ b/givoro-app/src/pages/solutions/index.js
@@ -1,0 +1,13 @@
+import Layout from '../../components/layout/Layout';
+import SolutionsGrid from '../../components/solutions/SolutionsGrid';
+
+export default function Solutions() {
+  return (
+    <Layout>
+      <main className="p-8 max-w-3xl mx-auto">
+        <h1 className="text-3xl font-bold mb-4">Solutions</h1>
+        <SolutionsGrid />
+      </main>
+    </Layout>
+  );
+}

--- a/givoro-app/src/styles/globals.css
+++ b/givoro-app/src/styles/globals.css
@@ -1,0 +1,7 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+
+html {
+  scroll-behavior: smooth;
+}

--- a/givoro-app/src/styles/tailwind.css
+++ b/givoro-app/src/styles/tailwind.css
@@ -1,0 +1,3 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;

--- a/givoro-app/src/utils/fetcher.js
+++ b/givoro-app/src/utils/fetcher.js
@@ -1,0 +1,5 @@
+export async function fetcher(url) {
+  const res = await fetch(url);
+  if (!res.ok) throw new Error('Network response was not ok');
+  return res.json();
+}

--- a/givoro-app/tailwind.config.js
+++ b/givoro-app/tailwind.config.js
@@ -4,6 +4,7 @@ module.exports = {
     './app/**/*.{js,ts,jsx,tsx}',
     './pages/**/*.{js,ts,jsx,tsx}',
     './components/**/*.{js,ts,jsx,tsx}',
+    './src/**/*.{js,ts,jsx,tsx}',
   ],
   theme: {
     extend: {


### PR DESCRIPTION
## Summary
- refactor site using `src` directory layout
- add layout, hero, about, solutions, platform, impact components
- provide simple pages under `src/pages`
- configure Tailwind to scan new files
- update README

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_687cbbd8fcc083279042b8b8a1aaeb69